### PR TITLE
Minor edits to background display of History and Search Users view

### DIFF
--- a/src/views/History.vue
+++ b/src/views/History.vue
@@ -117,7 +117,8 @@ body {
     
 .left-container {
     width: 30%; 
-    position: fixed;
+    position: absolute;
+    display: flex; 
     background-color: #2E2E2E;
     height: 80vh;
     overflow-y: auto;
@@ -175,6 +176,7 @@ body {
 }
     
 button {
+    display: flex; 
     border-radius: 1vw;
     border: none;
     padding: 0.7vw;
@@ -194,6 +196,7 @@ button {
 }
 .right-container label {
     margin-left: 1vw;
+    font-size: 1vw; 
   }
 
 .right-container input[type="text"], 

--- a/src/views/SearchUsers.vue
+++ b/src/views/SearchUsers.vue
@@ -49,14 +49,14 @@ export default {
     width: 30%; 
     position: fixed;
     background-color: #2E2E2E;
-    height: 80vh;
+    height: 100%;
     overflow-y: auto;
 }
 
 .left-text h3 {
     position: absolute;
     left: 10%;
-    top: 40%;  
+    top: 30%;  
     font-size: 4vw;
     margin: 0; 
     text-align: left;
@@ -75,7 +75,7 @@ export default {
 .encouragement-text { 
     position: absolute;
     left: 10%;
-    top: 45%;
+    top: 35%;
     transform: translateY(100%);
     text-align: left; 
     color: white;
@@ -87,7 +87,7 @@ export default {
 .searchUsers-view {
     display: flex;
     background-color: rgb(46, 46, 46);
-    min-height: 100vw;
+    height: 100%;
 }
 
 .searchUsers-header {


### PR DESCRIPTION
Previously, background had white spaces when different viewport sizes were used. Fixed it through minor edits in CSS